### PR TITLE
Add restart functionality

### DIFF
--- a/cases/convergence/cavityRe100/DirectForcing/circ_T00.25_20_0.00050/constant/180/simParams.yaml
+++ b/cases/convergence/cavityRe100/DirectForcing/circ_T00.25_20_0.00050/constant/180/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: DIRECT_FORCING
   interpolationType: CONSTANT

--- a/cases/convergence/cavityRe100/DirectForcing/circ_T00.25_20_0.00050/constant/20/simParams.yaml
+++ b/cases/convergence/cavityRe100/DirectForcing/circ_T00.25_20_0.00050/constant/20/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: DIRECT_FORCING
   interpolationType: CONSTANT

--- a/cases/convergence/cavityRe100/DirectForcing/circ_T00.25_20_0.00050/constant/540/simParams.yaml
+++ b/cases/convergence/cavityRe100/DirectForcing/circ_T00.25_20_0.00050/constant/540/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: DIRECT_FORCING
   interpolationType: CONSTANT

--- a/cases/convergence/cavityRe100/DirectForcing/circ_T00.25_20_0.00050/constant/60/simParams.yaml
+++ b/cases/convergence/cavityRe100/DirectForcing/circ_T00.25_20_0.00050/constant/60/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: DIRECT_FORCING
   interpolationType: CONSTANT

--- a/cases/convergence/cavityRe100/DirectForcing/circ_T00.25_20_0.00050/linear/180/simParams.yaml
+++ b/cases/convergence/cavityRe100/DirectForcing/circ_T00.25_20_0.00050/linear/180/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: DIRECT_FORCING
   interpolationType: LINEAR

--- a/cases/convergence/cavityRe100/DirectForcing/circ_T00.25_20_0.00050/linear/20/simParams.yaml
+++ b/cases/convergence/cavityRe100/DirectForcing/circ_T00.25_20_0.00050/linear/20/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: DIRECT_FORCING
   interpolationType: LINEAR

--- a/cases/convergence/cavityRe100/DirectForcing/circ_T00.25_20_0.00050/linear/540/simParams.yaml
+++ b/cases/convergence/cavityRe100/DirectForcing/circ_T00.25_20_0.00050/linear/540/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: DIRECT_FORCING
   interpolationType: LINEAR

--- a/cases/convergence/cavityRe100/DirectForcing/circ_T00.25_20_0.00050/linear/60/simParams.yaml
+++ b/cases/convergence/cavityRe100/DirectForcing/circ_T00.25_20_0.00050/linear/60/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: DIRECT_FORCING
   interpolationType: LINEAR

--- a/cases/convergence/cavityRe100/DirectForcing/quad_T00.25_20_0.00050/constant/180/simParams.yaml
+++ b/cases/convergence/cavityRe100/DirectForcing/quad_T00.25_20_0.00050/constant/180/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: DIRECT_FORCING
   interpolationType: CONSTANT

--- a/cases/convergence/cavityRe100/DirectForcing/quad_T00.25_20_0.00050/constant/20/simParams.yaml
+++ b/cases/convergence/cavityRe100/DirectForcing/quad_T00.25_20_0.00050/constant/20/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: DIRECT_FORCING
   interpolationType: CONSTANT

--- a/cases/convergence/cavityRe100/DirectForcing/quad_T00.25_20_0.00050/constant/540/simParams.yaml
+++ b/cases/convergence/cavityRe100/DirectForcing/quad_T00.25_20_0.00050/constant/540/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: DIRECT_FORCING
   interpolationType: CONSTANT

--- a/cases/convergence/cavityRe100/DirectForcing/quad_T00.25_20_0.00050/constant/60/simParams.yaml
+++ b/cases/convergence/cavityRe100/DirectForcing/quad_T00.25_20_0.00050/constant/60/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: DIRECT_FORCING
   interpolationType: CONSTANT

--- a/cases/convergence/cavityRe100/DirectForcing/quad_T00.25_20_0.00050/linear/180/simParams.yaml
+++ b/cases/convergence/cavityRe100/DirectForcing/quad_T00.25_20_0.00050/linear/180/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: DIRECT_FORCING
   interpolationType: LINEAR

--- a/cases/convergence/cavityRe100/DirectForcing/quad_T00.25_20_0.00050/linear/20/simParams.yaml
+++ b/cases/convergence/cavityRe100/DirectForcing/quad_T00.25_20_0.00050/linear/20/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: DIRECT_FORCING
   interpolationType: LINEAR

--- a/cases/convergence/cavityRe100/DirectForcing/quad_T00.25_20_0.00050/linear/540/simParams.yaml
+++ b/cases/convergence/cavityRe100/DirectForcing/quad_T00.25_20_0.00050/linear/540/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: DIRECT_FORCING
   interpolationType: LINEAR

--- a/cases/convergence/cavityRe100/DirectForcing/quad_T00.25_20_0.00050/linear/60/simParams.yaml
+++ b/cases/convergence/cavityRe100/DirectForcing/quad_T00.25_20_0.00050/linear/60/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: DIRECT_FORCING
   interpolationType: LINEAR

--- a/cases/convergence/cavityRe100/FadlunEtAl/circ_T00.25_20_0.00050/constant/180/simParams.yaml
+++ b/cases/convergence/cavityRe100/FadlunEtAl/circ_T00.25_20_0.00050/constant/180/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: FADLUN_ET_AL
   interpolationType: CONSTANT

--- a/cases/convergence/cavityRe100/FadlunEtAl/circ_T00.25_20_0.00050/constant/20/simParams.yaml
+++ b/cases/convergence/cavityRe100/FadlunEtAl/circ_T00.25_20_0.00050/constant/20/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: FADLUN_ET_AL
   interpolationType: CONSTANT

--- a/cases/convergence/cavityRe100/FadlunEtAl/circ_T00.25_20_0.00050/constant/540/simParams.yaml
+++ b/cases/convergence/cavityRe100/FadlunEtAl/circ_T00.25_20_0.00050/constant/540/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: FADLUN_ET_AL
   interpolationType: CONSTANT

--- a/cases/convergence/cavityRe100/FadlunEtAl/circ_T00.25_20_0.00050/constant/60/simParams.yaml
+++ b/cases/convergence/cavityRe100/FadlunEtAl/circ_T00.25_20_0.00050/constant/60/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: FADLUN_ET_AL
   interpolationType: CONSTANT

--- a/cases/convergence/cavityRe100/FadlunEtAl/circ_T00.25_20_0.00050/linear/180/simParams.yaml
+++ b/cases/convergence/cavityRe100/FadlunEtAl/circ_T00.25_20_0.00050/linear/180/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: FADLUN_ET_AL
   interpolationType: LINEAR

--- a/cases/convergence/cavityRe100/FadlunEtAl/circ_T00.25_20_0.00050/linear/20/simParams.yaml
+++ b/cases/convergence/cavityRe100/FadlunEtAl/circ_T00.25_20_0.00050/linear/20/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: FADLUN_ET_AL
   interpolationType: LINEAR

--- a/cases/convergence/cavityRe100/FadlunEtAl/circ_T00.25_20_0.00050/linear/540/simParams.yaml
+++ b/cases/convergence/cavityRe100/FadlunEtAl/circ_T00.25_20_0.00050/linear/540/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: FADLUN_ET_AL
   interpolationType: LINEAR

--- a/cases/convergence/cavityRe100/FadlunEtAl/circ_T00.25_20_0.00050/linear/60/simParams.yaml
+++ b/cases/convergence/cavityRe100/FadlunEtAl/circ_T00.25_20_0.00050/linear/60/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: FADLUN_ET_AL
   interpolationType: LINEAR

--- a/cases/convergence/cavityRe100/FadlunEtAl/quad_T00.25_20_0.00050/constant/180/simParams.yaml
+++ b/cases/convergence/cavityRe100/FadlunEtAl/quad_T00.25_20_0.00050/constant/180/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: FADLUN_ET_AL
   interpolationType: CONSTANT

--- a/cases/convergence/cavityRe100/FadlunEtAl/quad_T00.25_20_0.00050/constant/20/simParams.yaml
+++ b/cases/convergence/cavityRe100/FadlunEtAl/quad_T00.25_20_0.00050/constant/20/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: FADLUN_ET_AL
   interpolationType: CONSTANT

--- a/cases/convergence/cavityRe100/FadlunEtAl/quad_T00.25_20_0.00050/constant/540/simParams.yaml
+++ b/cases/convergence/cavityRe100/FadlunEtAl/quad_T00.25_20_0.00050/constant/540/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: FADLUN_ET_AL
   interpolationType: CONSTANT

--- a/cases/convergence/cavityRe100/FadlunEtAl/quad_T00.25_20_0.00050/constant/60/simParams.yaml
+++ b/cases/convergence/cavityRe100/FadlunEtAl/quad_T00.25_20_0.00050/constant/60/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: FADLUN_ET_AL
   interpolationType: CONSTANT

--- a/cases/convergence/cavityRe100/FadlunEtAl/quad_T00.25_20_0.00050/linear/180/simParams.yaml
+++ b/cases/convergence/cavityRe100/FadlunEtAl/quad_T00.25_20_0.00050/linear/180/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: FADLUN_ET_AL
   interpolationType: LINEAR

--- a/cases/convergence/cavityRe100/FadlunEtAl/quad_T00.25_20_0.00050/linear/20/simParams.yaml
+++ b/cases/convergence/cavityRe100/FadlunEtAl/quad_T00.25_20_0.00050/linear/20/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: FADLUN_ET_AL
   interpolationType: LINEAR

--- a/cases/convergence/cavityRe100/FadlunEtAl/quad_T00.25_20_0.00050/linear/540/simParams.yaml
+++ b/cases/convergence/cavityRe100/FadlunEtAl/quad_T00.25_20_0.00050/linear/540/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: FADLUN_ET_AL
   interpolationType: LINEAR

--- a/cases/convergence/cavityRe100/FadlunEtAl/quad_T00.25_20_0.00050/linear/60/simParams.yaml
+++ b/cases/convergence/cavityRe100/FadlunEtAl/quad_T00.25_20_0.00050/linear/60/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: FADLUN_ET_AL
   interpolationType: LINEAR

--- a/cases/convergence/cavityRe100/NavierStokes/20x20/180/simParams.yaml
+++ b/cases/convergence/cavityRe100/NavierStokes/20x20/180/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: NAVIER_STOKES
   linearSolvers:

--- a/cases/convergence/cavityRe100/NavierStokes/20x20/20/simParams.yaml
+++ b/cases/convergence/cavityRe100/NavierStokes/20x20/20/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: NAVIER_STOKES
   linearSolvers:

--- a/cases/convergence/cavityRe100/NavierStokes/20x20/540/simParams.yaml
+++ b/cases/convergence/cavityRe100/NavierStokes/20x20/540/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: NAVIER_STOKES
   linearSolvers:

--- a/cases/convergence/cavityRe100/NavierStokes/20x20/60/simParams.yaml
+++ b/cases/convergence/cavityRe100/NavierStokes/20x20/60/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: NAVIER_STOKES
   linearSolvers:

--- a/cases/convergence/cavityRe100/NavierStokes/32x32/288/simParams.yaml
+++ b/cases/convergence/cavityRe100/NavierStokes/32x32/288/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: NAVIER_STOKES
   linearSolvers:

--- a/cases/convergence/cavityRe100/NavierStokes/32x32/32/simParams.yaml
+++ b/cases/convergence/cavityRe100/NavierStokes/32x32/32/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: NAVIER_STOKES
   linearSolvers:

--- a/cases/convergence/cavityRe100/NavierStokes/32x32/864/simParams.yaml
+++ b/cases/convergence/cavityRe100/NavierStokes/32x32/864/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: NAVIER_STOKES
   linearSolvers:

--- a/cases/convergence/cavityRe100/NavierStokes/32x32/96/simParams.yaml
+++ b/cases/convergence/cavityRe100/NavierStokes/32x32/96/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0005
   scaleCV: 5.0
+  startStep: 0
   nt: 500
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_IMPLICIT]
   ibmScheme: NAVIER_STOKES
   linearSolvers:

--- a/cases/cylinder/Re100/simParams.yaml
+++ b/cases/cylinder/Re100/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.005
   scaleCV: 5.0
+  startStep: 0
   nt: 16000
   nsave: 1600
-  restart: false
-  startStep: 0
   timeScheme: [ADAMS_BASHFORTH_2, CRANK_NICOLSON]
   ibmScheme: TAIRA_COLONIUS
   linearSolvers:

--- a/cases/cylinder/Re150/simParams.yaml
+++ b/cases/cylinder/Re150/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.005
   scaleCV: 5.0
+  startStep: 0
   nt: 16000
   nsave: 1600
-  restart: false
-  startStep: 0
   timeScheme: [ADAMS_BASHFORTH_2, CRANK_NICOLSON]
   ibmScheme: TAIRA_COLONIUS
   linearSolvers:

--- a/cases/cylinder/Re3000/simParams.yaml
+++ b/cases/cylinder/Re3000/simParams.yaml
@@ -1,6 +1,7 @@
 - type: simulation
   dt: 0.001
   scaleCV: 5.0
+  startStep: 0
   nt: 3000
   nsave: 500
   timeScheme: [ADAMS_BASHFORTH_2, CRANK_NICOLSON]

--- a/cases/cylinder/Re40/simParams.yaml
+++ b/cases/cylinder/Re40/simParams.yaml
@@ -1,5 +1,6 @@
 - type: simulation
   dt: 0.01
+  startStep: 0
   nt: 300
   nsave: 50
   timeScheme: [ADAMS_BASHFORTH_2, CRANK_NICOLSON]

--- a/cases/cylinder/Re550/simParams.yaml
+++ b/cases/cylinder/Re550/simParams.yaml
@@ -1,5 +1,6 @@
 - type: simulation
   dt: 0.0025
+  startStep: 0
   nt: 1200
   nsave: 200
   timeScheme: [ADAMS_BASHFORTH_2, CRANK_NICOLSON]

--- a/cases/cylinder/Re75/simParams.yaml
+++ b/cases/cylinder/Re75/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.005
   scaleCV: 5.0
+  startStep: 0
   nt: 16000
   nsave: 1600
-  restart: false
-  startStep: 0
   timeScheme: [ADAMS_BASHFORTH_2, CRANK_NICOLSON]
   ibmScheme: TAIRA_COLONIUS
   linearSolvers:

--- a/cases/cylinder/test/simParams.yaml
+++ b/cases/cylinder/test/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.03
   scaleCV: 5.0
+  startStep: 0
   nt: 200
   nsave: 50
-  restart: false
-  startStep: 0
   timeScheme: [ADAMS_BASHFORTH_2, CRANK_NICOLSON]
   ibmScheme: TAIRA_COLONIUS
   linearSolvers:

--- a/cases/flappingRe75/simParams.yaml
+++ b/cases/flappingRe75/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.001
   scaleCV: 5.0
+  startStep: 0
   nt: 4000
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [ADAMS_BASHFORTH_2, CRANK_NICOLSON]
   ibmScheme: TAIRA_COLONIUS
   linearSolvers:

--- a/cases/flyingSnake/Re1000_AoA30/simParams.yaml
+++ b/cases/flyingSnake/Re1000_AoA30/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0004
   scaleCV: 5.0
+  startStep: 0
   nt: 200000
   nsave: 20000
-  restart: false
-  startStep: 0
   timeScheme: [ADAMS_BASHFORTH_2, CRANK_NICOLSON]
   ibmScheme: TAIRA_COLONIUS
   linearSolvers:

--- a/cases/flyingSnake/Re1000_AoA35/simParams.yaml
+++ b/cases/flyingSnake/Re1000_AoA35/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0004
   scaleCV: 5.0
+  startStep: 0
   nt: 200000
   nsave: 20000
-  restart: false
-  startStep: 0
   timeScheme: [ADAMS_BASHFORTH_2, CRANK_NICOLSON]
   ibmScheme: TAIRA_COLONIUS
   linearSolvers:

--- a/cases/flyingSnake/Re2000_AoA30/simParams.yaml
+++ b/cases/flyingSnake/Re2000_AoA30/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0004
   scaleCV: 5.0
+  startStep: 0
   nt: 200000
   nsave: 20000
-  restart: false
-  startStep: 0
   timeScheme: [ADAMS_BASHFORTH_2, CRANK_NICOLSON]
   ibmScheme: TAIRA_COLONIUS
   linearSolvers:

--- a/cases/flyingSnake/Re2000_AoA35/simParams.yaml
+++ b/cases/flyingSnake/Re2000_AoA35/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0004
   scaleCV: 5.0
+  startStep: 0
   nt: 200000
   nsave: 20000
-  restart: false
-  startStep: 0
   timeScheme: [ADAMS_BASHFORTH_2, CRANK_NICOLSON]
   ibmScheme: TAIRA_COLONIUS
   linearSolvers:

--- a/cases/lidDrivenCavity/Re100/simParams.yaml
+++ b/cases/lidDrivenCavity/Re100/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.01
   scaleCV: 5.0
+  startStep: 0
   nt: 1000
   nsave: 1000
-  restart: false
-  startStep: 0
   timeScheme: [ADAMS_BASHFORTH_2, CRANK_NICOLSON]
   ibmScheme: NAVIER_STOKES
   linearSolvers:

--- a/cases/lidDrivenCavity/Re1000/simParams.yaml
+++ b/cases/lidDrivenCavity/Re1000/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.004
   scaleCV: 5.0
+  startStep: 0
   nt: 10000
   nsave: 10000
-  restart: false
-  startStep: 0
   timeScheme: [ADAMS_BASHFORTH_2, CRANK_NICOLSON]
   ibmScheme: NAVIER_STOKES
   linearSolvers:

--- a/cases/lidDrivenCavity/Re10000/simParams.yaml
+++ b/cases/lidDrivenCavity/Re10000/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.002
   scaleCV: 5.0
+  startStep: 0
   nt: 40000
   nsave: 5000
-  restart: false
-  startStep: 0
   timeScheme: [ADAMS_BASHFORTH_2, CRANK_NICOLSON]
   ibmScheme: NAVIER_STOKES
   linearSolvers:

--- a/cases/oscillatingCylinders/simParams.yaml
+++ b/cases/oscillatingCylinders/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.005
   scaleCV: 5.0
+  startStep: 0
   nt: 2400
   nsave: 100
-  restart: false
-  startStep: 0
   timeScheme: [ADAMS_BASHFORTH_2, CRANK_NICOLSON]
   ibmScheme: TAIRA_COLONIUS
   linearSolvers:

--- a/cases/unitTests/convectionTerm/12/simParams.yaml
+++ b/cases/unitTests/convectionTerm/12/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.02
   scaleCV: 5.0
+  startStep: 0
   nt: 1
   nsave: 1
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_EXPLICIT]
   ibmScheme: NAVIER_STOKES
   linearSolvers:

--- a/cases/unitTests/convectionTerm/24/simParams.yaml
+++ b/cases/unitTests/convectionTerm/24/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.02
   scaleCV: 5.0
+  startStep: 0
   nt: 1
   nsave: 1
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_EXPLICIT]
   ibmScheme: NAVIER_STOKES
   linearSolvers:

--- a/cases/unitTests/convectionTerm/48/simParams.yaml
+++ b/cases/unitTests/convectionTerm/48/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.02
   scaleCV: 5.0
+  startStep: 0
   nt: 1
   nsave: 1
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_EXPLICIT]
   ibmScheme: NAVIER_STOKES
   linearSolvers:

--- a/cases/unitTests/convectionTerm/6/simParams.yaml
+++ b/cases/unitTests/convectionTerm/6/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.02
   scaleCV: 5.0
+  startStep: 0
   nt: 1
   nsave: 1
-  restart: false
-  startStep: 0
   timeScheme: [EULER_EXPLICIT, EULER_EXPLICIT]
   ibmScheme: NAVIER_STOKES
   linearSolvers:

--- a/scripts/python/plotVorticity.py
+++ b/scripts/python/plotVorticity.py
@@ -62,7 +62,7 @@ def main():
 	Omg = np.zeros((j_end-j_start, i_end-i_start))
 
 	# time-loop
-	for ite in xrange(start_step+nsave, nt+1, nsave):
+	for ite in xrange(start_step+nsave, start_step+nt+1, nsave):
 		# read the velocity data at the given time-step
 		u, v = readVelocityData(folder, ite, nx, ny, dx, dy)
 		if u == None or v == None:

--- a/src/io/io.cu
+++ b/src/io/io.cu
@@ -35,23 +35,6 @@ std::vector<std::string> split(const std::string &s, char delim) {
     return elems;
 }
 
-void makeDirectory(const std::string folderPath)
-{
-	std::vector<std::string> x = split(folderPath, '/');
-	int n = x.size();
-	int i = 0;
-	std::string folder = x[i];
-	mkdir(folder.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
-	i++;
-	while(i<n)
-	{
-		folder = folder + '/' + x[i];
-		mkdir(folder.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
-		i++;
-	}
-}
-
-
 //##############################################################################
 //                                 INPUT
 //##############################################################################

--- a/src/io/io.cu
+++ b/src/io/io.cu
@@ -422,6 +422,20 @@ void writeData<vecD>(std::string &caseFolder, int n, vecD &q, vecD &lambda, doma
 	writeData(caseFolder, n, qH, lambdaH, D);
 }
 
+void readData(std::string &caseFolder, int timeStep, real *q)
+{
+	std::stringstream in;
+	std::string inFilePath;
+	int numQ;
+
+	in << caseFolder << "/" << std::setfill('0') << std::setw(7) << timeStep << "/q";
+	inFilePath = in.str();
+	std::ifstream inFile(inFilePath.c_str(), std::ifstream::binary);
+	inFile.read((char*)(&numQ), sizeof(int));
+	inFile.read((char*)(&q[0]), numQ*sizeof(real));
+	inFile.close();
+}
+
 void printDeviceMemoryUsage(char *label)
 {
 	size_t _free, _total;

--- a/src/io/io.cu
+++ b/src/io/io.cu
@@ -422,17 +422,17 @@ void writeData<vecD>(std::string &caseFolder, int n, vecD &q, vecD &lambda, doma
 	writeData(caseFolder, n, qH, lambdaH, D);
 }
 
-void readData(std::string &caseFolder, int timeStep, real *q)
+void readData(std::string &caseFolder, int timeStep, real *x, std::string name)
 {
 	std::stringstream in;
 	std::string inFilePath;
-	int numQ;
+	int n;
 
-	in << caseFolder << "/" << std::setfill('0') << std::setw(7) << timeStep << "/q";
+	in << caseFolder << "/" << std::setfill('0') << std::setw(7) << timeStep << "/" << name;
 	inFilePath = in.str();
 	std::ifstream inFile(inFilePath.c_str(), std::ifstream::binary);
-	inFile.read((char*)(&numQ), sizeof(int));
-	inFile.read((char*)(&q[0]), numQ*sizeof(real));
+	inFile.read((char*)(&n), sizeof(int));
+	inFile.read((char*)(&x[0]), n*sizeof(real));
 	inFile.close();
 }
 

--- a/src/io/io.cu
+++ b/src/io/io.cu
@@ -102,7 +102,6 @@ void initialiseDefaultDB(parameterDB &DB)
 	DB[sim]["dt"].set<real>(0.02);
 	DB[sim]["nt"].set<int>(100);
 	DB[sim]["nsave"].set<int>(100);
-	DB[sim]["restart"].set<bool>(false);
 	DB[sim]["startStep"].set<bool>(0);
 	DB[sim]["convTimeScheme"].set<timeScheme>(EULER_EXPLICIT);
 	DB[sim]["diffTimeScheme"].set<timeScheme>(EULER_IMPLICIT);

--- a/src/io/io.h
+++ b/src/io/io.h
@@ -41,6 +41,6 @@ namespace io
 	void writeGrid(std::string &caseFolder, domain &D);
 	template <typename Vector>
 	void writeData(std::string &caseFolder, int n, Vector &q, Vector &lambda, domain &D);//, bodies &B);
-	void readData(std::string &caseFolder, int timeStep, real *q);
+	void readData(std::string &caseFolder, int timeStep, real *q, std::string name);
 	void printDeviceMemoryUsage(char *label);
 }

--- a/src/io/io.h
+++ b/src/io/io.h
@@ -19,7 +19,6 @@ namespace io
 {
 	std::vector<std::string> &split(const std::string &s, char delim, std::vector<std::string> &elems);
 	std::vector<std::string> split(const std::string &s, char delim);
-	void makeDirectory(const std::string s);
 	
 	// input
 	void readInputs(int argc, char **argv, parameterDB &DB, domain &D); 

--- a/src/io/io.h
+++ b/src/io/io.h
@@ -41,5 +41,6 @@ namespace io
 	void writeGrid(std::string &caseFolder, domain &D);
 	template <typename Vector>
 	void writeData(std::string &caseFolder, int n, Vector &q, Vector &lambda, domain &D);//, bodies &B);
+	void readData(std::string &caseFolder, int timeStep, real *q);
 	void printDeviceMemoryUsage(char *label);
 }

--- a/src/io/parseSimulationFile.cu
+++ b/src/io/parseSimulationFile.cu
@@ -66,28 +66,19 @@ void parseSimulation(const YAML::Node &node, parameterDB &DB)
 {
 	real   dt = 0.02,
 	       scaleCV = 2.0;
-	int    nt = 100,
-	       nsave = 100,
-	       startStep = 0;
+	int    startStep = 0,
+	       nt = 100,
+	       nsave = 100;
 	string ibmSch = "NAVIER_STOKES",
 	       convSch = "EULER_EXPLICIT",
 	       diffSch = "EULER_IMPLICIT",
 	       interpType = "LINEAR";
-	bool   restart = false;
-
 
 	// read simulation parameters
 	node["dt"] >> dt;
 	node["nsave"] >> nsave;
 	node["nt"] >> nt;
 	node["ibmScheme"] >> ibmSch;
-	try
-	{
-		node["restart"] >> restart;
-	}
-	catch(...)
-	{
-	}
 	try
 	{
 		node["startStep"] >> startStep;
@@ -122,9 +113,9 @@ void parseSimulation(const YAML::Node &node, parameterDB &DB)
 	string dbKey = "simulation";
 	DB[dbKey]["dt"].set<real>(dt);
 	DB[dbKey]["scaleCV"].set<real>(scaleCV);
-	DB[dbKey]["nsave"].set<int>(nsave);
+	DB[dbKey]["startStep"].set<int>(startStep);
 	DB[dbKey]["nt"].set<int>(nt);
-	DB[dbKey]["restart"].set<bool>(restart);
+	DB[dbKey]["nsave"].set<int>(nsave);
 	DB[dbKey]["ibmScheme"].set<ibmScheme>(ibmSchemeFromString(ibmSch));
 	DB[dbKey]["convTimeScheme"].set<timeScheme>(timeSchemeFromString(convSch));
 	DB[dbKey]["diffTimeScheme"].set<timeScheme>(timeSchemeFromString(diffSch));

--- a/src/solvers/NavierStokes/NSWithBody.cu
+++ b/src/solvers/NavierStokes/NSWithBody.cu
@@ -13,7 +13,15 @@ void NSWithBody<memoryType>::initialiseBodies()
 	std::string folder = db["inputs"]["caseFolder"].get<std::string>();
 	std::stringstream out;
 	out << folder << "/forces";
-	forceFile.open(out.str().c_str());
+	int timeStep(db["simulation"]["startStep"].get<int>());
+	if (timeStep != 0)
+	{
+		forceFile.open(out.str().c_str(), std::ofstream::app);
+	}
+	else
+	{
+		forceFile.open(out.str().c_str());
+	}
 	
 	NavierStokesSolver<memoryType>::logger.stopTimer("initialiseBodies");
 }

--- a/src/solvers/NavierStokes/NavierStokesSolver.cu
+++ b/src/solvers/NavierStokes/NavierStokesSolver.cu
@@ -38,9 +38,8 @@ void NavierStokesSolver<memoryType>::initialiseCommon()
 	/// initial values of timeStep
 	timeStep = (*paramDB)["simulation"]["startStep"].get<int>();
 	
-	/// create directory 
+	/// get the case directory
 	std::string folder = (*paramDB)["inputs"]["caseFolder"].get<std::string>();
-	io::makeDirectory(folder);
 
 	/// write the grids information to a file
 	io::writeGrid(folder, *domInfo);

--- a/src/solvers/NavierStokes/NavierStokesSolver.cu
+++ b/src/solvers/NavierStokes/NavierStokesSolver.cu
@@ -47,7 +47,14 @@ void NavierStokesSolver<memoryType>::initialiseCommon()
 	/// open the required files
 	std::stringstream out;
 	out << folder << "/iterations";
-	iterationsFile.open(out.str().c_str());
+	if (timeStep != 0)
+	{
+		iterationsFile.open(out.str().c_str(), std::ofstream::app);
+	}
+	else
+	{
+		iterationsFile.open(out.str().c_str());
+	}
 	
 	/// write the plot information to a file
 	

--- a/src/solvers/NavierStokes/NavierStokesSolver.cu
+++ b/src/solvers/NavierStokes/NavierStokesSolver.cu
@@ -94,8 +94,6 @@ void NavierStokesSolver<memoryType>::initialiseArrays(int numQ, int numLambda)
 	cusp::blas::fill(temp2, 0.0);
 	
 	initialiseFluxes();
-	if (timeStep != 0)
-		initializeLambda();
 	initialiseBoundaryArrays();
 	
 	generateRN();
@@ -103,31 +101,6 @@ void NavierStokesSolver<memoryType>::initialiseArrays(int numQ, int numLambda)
 	std::cout << "Initialised arrays!" << std::endl;
 	
 	logger.stopTimer("initialiseArrays");
-}
-
-template <>
-void NavierStokesSolver<host_memory>::initializeLambda()
-{
-	real *lambda_r = thrust::raw_pointer_cast(&lambda[0]);
-	initializeLambda(lambda_r);
-}
-
-template <>
-void NavierStokesSolver<device_memory>::initializeLambda()
-{
-	vecH lambdaHost = lambda;
-	real *lambdaHost_r = thrust::raw_pointer_cast(&lambdaHost[0]);
-	initializeLambda(lambdaHost_r);
-	lambda = lambdaHost;
-}
-
-template <typename memoryType>
-void NavierStokesSolver<memoryType>::initializeLambda(real *lambda)
-{
-	// case directory
-	std::string caseFolder = (*paramDB)["inputs"]["caseFolder"].get<std::string>();
-	// read pressure (and forces if body) from file
-	io::readData(caseFolder, timeStep, lambda, "lambda");
 }
 
 /**
@@ -193,6 +166,7 @@ void NavierStokesSolver <memoryType>::initialiseFluxes(real *q)
 	{
 		// case directory
 		std::string caseFolder = (*paramDB)["inputs"]["caseFolder"].get<std::string>();
+		std::cout << "Hello: " << caseFolder << std::endl;
 		// read velocity fluxes from file
 		io::readData(caseFolder, timeStep, q, "q");
 	}

--- a/src/solvers/NavierStokes/NavierStokesSolver.h
+++ b/src/solvers/NavierStokes/NavierStokesSolver.h
@@ -59,6 +59,8 @@ protected:
 	void initialiseArrays(int numQ, int numLambda);
 	virtual void initialiseFluxes();
 	virtual void initialiseFluxes(real *q);
+	void initializeLambda();
+	void initializeLambda(real *lambda);
 	void initialiseBoundaryArrays();
 	void assembleMatrices(); // contains subfunctions to calculate A, QT, BN, QTBNQ
 

--- a/src/solvers/NavierStokes/NavierStokesSolver.h
+++ b/src/solvers/NavierStokes/NavierStokesSolver.h
@@ -59,8 +59,6 @@ protected:
 	void initialiseArrays(int numQ, int numLambda);
 	virtual void initialiseFluxes();
 	virtual void initialiseFluxes(real *q);
-	void initializeLambda();
-	void initializeLambda(real *lambda);
 	void initialiseBoundaryArrays();
 	void assembleMatrices(); // contains subfunctions to calculate A, QT, BN, QTBNQ
 

--- a/validation/NACA0008/AoA04_0.002/simParams.yaml
+++ b/validation/NACA0008/AoA04_0.002/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0002
   scaleCV: 5.0
+  startStep: 0
   nt: 60000
   nsave: 60000
-  restart: false
-  startStep: 0
   timeScheme: [ADAMS_BASHFORTH_2, CRANK_NICOLSON]
   ibmScheme: TAIRA_COLONIUS
   linearSolvers:

--- a/validation/NACA0008/AoA04_0.004/simParams.yaml
+++ b/validation/NACA0008/AoA04_0.004/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0004
   scaleCV: 5.0
+  startStep: 0
   nt: 30000
   nsave: 30000
-  restart: false
-  startStep: 0
   timeScheme: [ADAMS_BASHFORTH_2, CRANK_NICOLSON]
   ibmScheme: TAIRA_COLONIUS
   linearSolvers:

--- a/validation/cylinder/Re3000/simParams.yaml
+++ b/validation/cylinder/Re3000/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.001
   scaleCV: 5.0
+  startStep: 0
   nt: 3000
   nsave: 500
-  restart: false
-  startStep: 0
   timeScheme: [ADAMS_BASHFORTH_2, CRANK_NICOLSON]
   ibmScheme: TAIRA_COLONIUS
   linearSolvers:

--- a/validation/cylinder/Re40/simParams.yaml
+++ b/validation/cylinder/Re40/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.005
   scaleCV: 5.0
+  startStep: 0
   nt: 600
   nsave: 100
-  restart: false
-  startStep: 0
   timeScheme: [ADAMS_BASHFORTH_2, CRANK_NICOLSON]
   ibmScheme: TAIRA_COLONIUS
   linearSolvers:

--- a/validation/cylinder/Re550/simParams.yaml
+++ b/validation/cylinder/Re550/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.0025
   scaleCV: 5.0
+  startStep: 0
   nt: 1200
   nsave: 200
-  restart: false
-  startStep: 0
   timeScheme: [ADAMS_BASHFORTH_2, CRANK_NICOLSON]
   ibmScheme: TAIRA_COLONIUS
   linearSolvers:

--- a/validation/lidDrivenCavity/Re100/simParams.yaml
+++ b/validation/lidDrivenCavity/Re100/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.01
   scaleCV: 5.0
+  startStep: 0
   nt: 1000
   nsave: 1000
-  restart: false
-  startStep: 0
   timeScheme: [ADAMS_BASHFORTH_2, CRANK_NICOLSON]
   ibmScheme: NAVIER_STOKES
   linearSolvers:

--- a/validation/lidDrivenCavity/Re1000/simParams.yaml
+++ b/validation/lidDrivenCavity/Re1000/simParams.yaml
@@ -1,10 +1,9 @@
 - type: simulation
   dt: 0.004
   scaleCV: 5.0
+  startStep: 0
   nt: 10000
   nsave: 10000
-  restart: false
-  startStep: 0
   timeScheme: [ADAMS_BASHFORTH_2, CRANK_NICOLSON]
   ibmScheme: NAVIER_STOKES
   linearSolvers:


### PR DESCRIPTION
If the value of the parameter `startStep` is different from zero in the file `simParams.yaml` that is located in the simulation case directory, the fluxes are read from file at initial step.

If the simulation is started from a time-step different from zero, info about iterations and forces are appended to the existing corresponding files.

The Boolean flag `restart` has been removed from all the `simParams.yaml` files.

When running some test with on the cylinder at Re=40, it notice some things:
- as expected, the number of iterations for the Poisson solver is bigger when the simulation is restarted, than the number when running in one strike,
- the drag coefficient is different just after restarting (higher value), and remains different for some iterations.

The pull request should not be merged before @anushkrish agrees on the method and the implementation in cuIBM.