### PR TITLE
Correct drag calculation and add restart functionality

### DIFF
--- a/src/io/io.cu
+++ b/src/io/io.cu
@@ -577,6 +577,35 @@ void writeData<vecD>(std::string &caseFolder, int n, vecD &q, vecD &lambda, doma
 	writeData(caseFolder, n, qH, lambdaH, D);
 }
 
+
+/**
+ * \brief Reads numerical data at a given time-step.
+ *
+ * \param caseFolder directory of the simulation
+ * \param timeStep the time-step number
+ * \param x array that to fill
+ * \param name name of the file containing the variable
+ */
+void readData(std::string &caseFolder, int timeStep, real *x, std::string name)
+{
+	std::stringstream in;
+	std::string inFilePath;
+	int n;
+
+	in << caseFolder << "/" << std::setfill('0') << std::setw(7) << timeStep << "/" << name;
+	inFilePath = in.str();
+	std::cout << "Reading fluxes from " << inFilePath << " ...";
+	std::ifstream inFile(inFilePath.c_str());
+	inFile >> n;
+	for (int i=0; i<n; i++)
+	{
+	       inFile >> x[i];
+	}
+	inFile.close();
+	std::cout << "done" << std::endl;
+}
+
+
 /**
  * \brief Prints device memory usage.
  *

--- a/src/io/io.cu
+++ b/src/io/io.cu
@@ -69,29 +69,6 @@ std::vector<std::string> split(const std::string &s, char delim) {
     return elems;
 }
 
-/**
- * \brief Creates a directory.
- *
- * If the parent directory does not exist, it will be created.
- *
- * \param folderPath the path of the directory to create
- */
-void makeDirectory(const std::string folderPath)
-{
-	std::vector<std::string> x = split(folderPath, '/');
-	int n = x.size();
-	int i = 0;
-	std::string folder = x[i];
-	mkdir(folder.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
-	i++;
-	while(i<n)
-	{
-		folder = folder + '/' + x[i];
-		mkdir(folder.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
-		i++;
-	}
-}
-
 //##############################################################################
 //                                 INPUT
 //##############################################################################
@@ -172,7 +149,6 @@ void initialiseDefaultDB(parameterDB &DB)
 	DB[sim]["dt"].set<real>(0.02);
 	DB[sim]["nt"].set<int>(100);
 	DB[sim]["nsave"].set<int>(100);
-	DB[sim]["restart"].set<bool>(false);
 	DB[sim]["startStep"].set<bool>(0);
 	DB[sim]["convTimeScheme"].set<timeScheme>(EULER_EXPLICIT);
 	DB[sim]["diffTimeScheme"].set<timeScheme>(EULER_IMPLICIT);
@@ -594,13 +570,10 @@ void readData(std::string &caseFolder, int timeStep, real *x, std::string name)
 
 	in << caseFolder << "/" << std::setfill('0') << std::setw(7) << timeStep << "/" << name;
 	inFilePath = in.str();
-	std::cout << "Reading fluxes from " << inFilePath << " ...";
-	std::ifstream inFile(inFilePath.c_str());
-	inFile >> n;
-	for (int i=0; i<n; i++)
-	{
-	       inFile >> x[i];
-	}
+	std::cout << "Reading fluxes from " << inFilePath << " ... ";
+	std::ifstream inFile(inFilePath.c_str(), std::ifstream::binary);
+	inFile.read((char*)(&n), sizeof(int));
+	inFile.read((char*)(&x[0]), n*sizeof(real));
 	inFile.close();
 	std::cout << "done" << std::endl;
 }

--- a/src/io/io.h
+++ b/src/io/io.h
@@ -25,9 +25,6 @@ namespace io
 	
 	// split a string given a delimiter
 	std::vector<std::string> split(const std::string &s, char delim);
-
-	// create a directory
-	void makeDirectory(const std::string s);
 	
 	// read data inputs from the command-line and the simulation files
 	void readInputs(int argc, char **argv, parameterDB &DB, domain &D); 

--- a/src/io/io.h
+++ b/src/io/io.h
@@ -69,6 +69,9 @@ namespace io
 	template <typename Vector>
 	void writeData(std::string &caseFolder, int n, Vector &q, Vector &lambda, domain &D);//, bodies &B);
 	
+	// read numerical data at a given time-step
+	void readData(std::string &caseFolder, int timeStep, real *x, std::string name);
+
 	// print device memory usage
 	void printDeviceMemoryUsage(char *label);
 }

--- a/src/io/parseSimulationFile.cu
+++ b/src/io/parseSimulationFile.cu
@@ -183,6 +183,7 @@ void parseSimulation(const YAML::Node &node, parameterDB &DB)
 	DB[dbKey]["scaleCV"].set<real>(scaleCV);
 	DB[dbKey]["nsave"].set<int>(nsave);
 	DB[dbKey]["nt"].set<int>(nt);
+  DB[dbKey]["startStep"].set<int>(startStep);
 	DB[dbKey]["restart"].set<bool>(restart);
 	DB[dbKey]["ibmScheme"].set<ibmScheme>(ibmSchemeFromString(ibmSch));
 	DB[dbKey]["convTimeScheme"].set<timeScheme>(timeSchemeFromString(convSch));

--- a/src/io/parseSimulationFile.cu
+++ b/src/io/parseSimulationFile.cu
@@ -132,7 +132,6 @@ void parseSimulation(const YAML::Node &node, parameterDB &DB)
 	       convSch = "EULER_EXPLICIT",
 	       diffSch = "EULER_IMPLICIT",
 	       interpType = "LINEAR";
-	bool   restart = false;
 
 
 	// read simulation parameters
@@ -140,13 +139,6 @@ void parseSimulation(const YAML::Node &node, parameterDB &DB)
 	node["nsave"] >> nsave;
 	node["nt"] >> nt;
 	node["ibmScheme"] >> ibmSch;
-	try
-	{
-		node["restart"] >> restart;
-	}
-	catch(...)
-	{
-	}
 	try
 	{
 		node["startStep"] >> startStep;
@@ -184,7 +176,6 @@ void parseSimulation(const YAML::Node &node, parameterDB &DB)
 	DB[dbKey]["nsave"].set<int>(nsave);
 	DB[dbKey]["nt"].set<int>(nt);
   DB[dbKey]["startStep"].set<int>(startStep);
-	DB[dbKey]["restart"].set<bool>(restart);
 	DB[dbKey]["ibmScheme"].set<ibmScheme>(ibmSchemeFromString(ibmSch));
 	DB[dbKey]["convTimeScheme"].set<timeScheme>(timeSchemeFromString(convSch));
 	DB[dbKey]["diffTimeScheme"].set<timeScheme>(timeSchemeFromString(diffSch));

--- a/src/solvers/NavierStokes/NSWithBody.cu
+++ b/src/solvers/NavierStokes/NSWithBody.cu
@@ -24,7 +24,15 @@ void NSWithBody<memoryType>::initialiseBodies()
 	std::string folder = db["inputs"]["caseFolder"].get<std::string>();
 	std::stringstream out;
 	out << folder << "/forces";
-	forceFile.open(out.str().c_str());
+	int timeStep(db["simulation"]["startStep"].get<int>());
+	if (timeStep != 0)
+	{
+		forceFile.open(out.str().c_str(), std::ofstream::app);
+	}
+	else
+	{
+		forceFile.open(out.str().c_str());
+	}
 	
 	NavierStokesSolver<memoryType>::logger.stopTimer("initialiseBodies");
 }

--- a/src/solvers/NavierStokes/NavierStokes/generateRN.inl
+++ b/src/solvers/NavierStokes/NavierStokes/generateRN.inl
@@ -50,6 +50,12 @@ void NavierStokesSolver<device_memory>::calculateExplicitQTerms()
 	     zeta = intgSchm.zeta[subStep],
 	     alpha = intgSchm.alphaExplicit[subStep],
 	     nu = (*paramDB)["flow"]["nu"].get<real>();
+	// if first time-step: use Euler explicit for convective terms
+	if (timeStep == (*paramDB)["simulation"]["startStep"].get<int>())
+	{
+		gamma = 1.0;
+		zeta = 0.0;
+	}
 	     
 	// raw pointers for cup arrays
 	real *H_r  = thrust::raw_pointer_cast(&H[0]),

--- a/src/solvers/NavierStokes/NavierStokesSolver.cu
+++ b/src/solvers/NavierStokes/NavierStokesSolver.cu
@@ -61,7 +61,14 @@ void NavierStokesSolver<memoryType>::initialiseCommon()
 	// opens the file to which the number of iterations at every step is written
 	std::stringstream out;
 	out << folder << "/iterations";
-	iterationsFile.open(out.str().c_str());
+	if (timeStep == 0)
+	{
+		iterationsFile.open(out.str().c_str());
+	}
+	else
+	{
+		iterationsFile.open(out.str().c_str(), std::ofstream::app);
+	}
 	
 	std::cout << "Initialised common stuff!" << std::endl;
 	
@@ -156,6 +163,16 @@ void NavierStokesSolver <device_memory>::initialiseFluxes()
 template <typename memoryType>
 void NavierStokesSolver <memoryType>::initialiseFluxes(real *q)
 {
+	if (timeStep != 0)
+	{
+		// case directory
+		std::string caseFolder = (*paramDB)["inputs"]["folderName"].get<std::string>();
+		std::cout << "Hello: " << caseFolder << std::endl;
+		// read velocity fluxes from file
+		io::readData(caseFolder, timeStep, q, "q");
+		return;
+	}
+
 	int  nx = domInfo->nx,
 	     ny = domInfo->ny,
 	     numU  = (nx-1)*ny;
@@ -300,8 +317,9 @@ void NavierStokesSolver<memoryType>::updateBoundaryConditions()
 template <typename memoryType>
 bool NavierStokesSolver<memoryType>::finished()
 {
+	int startStep = (*paramDB)["simulation"]["startStep"].get<int>();
 	int nt = (*paramDB)["simulation"]["nt"].get<int>();
-	return (timeStep < nt) ? false : true;
+	return (timeStep < startStep+nt) ? false : true;
 }
 
 //##############################################################################

--- a/src/solvers/NavierStokes/NavierStokesSolver.cu
+++ b/src/solvers/NavierStokes/NavierStokesSolver.cu
@@ -48,12 +48,10 @@ void NavierStokesSolver<memoryType>::initialiseCommon()
 	           diffScheme = (*paramDB)["simulation"]["diffTimeScheme"].get<timeScheme>();
 	intgSchm.initialise(convScheme, diffScheme);
 	
-	// initial values of timeStep
+	// set initial timeStep
 	timeStep = (*paramDB)["simulation"]["startStep"].get<int>();
-	
-	// creates directory 
+	// get folder path 
 	std::string folder = (*paramDB)["inputs"]["caseFolder"].get<std::string>();
-	io::makeDirectory(folder);
 
 	// writes the grids information to a file
 	io::writeGrid(folder, *domInfo);
@@ -166,8 +164,7 @@ void NavierStokesSolver <memoryType>::initialiseFluxes(real *q)
 	if (timeStep != 0)
 	{
 		// case directory
-		std::string caseFolder = (*paramDB)["inputs"]["folderName"].get<std::string>();
-		std::cout << "Hello: " << caseFolder << std::endl;
+		std::string caseFolder = (*paramDB)["inputs"]["caseFolder"].get<std::string>();
 		// read velocity fluxes from file
 		io::readData(caseFolder, timeStep, q, "q");
 		return;

--- a/src/solvers/NavierStokes/TairaColonius/calculateForce.inl
+++ b/src/solvers/NavierStokes/TairaColonius/calculateForce.inl
@@ -52,6 +52,11 @@ void TairaColoniusSolver<memoryType>::calculateForce()
 			fView = View(fTemp.begin() + NSWithBody<memoryType>::B.offsets[l+1], fTemp.end());
 			cusp::blas::fill(fView, 0.0);
 		}
+		else
+		{
+			fView = View(fTemp.begin() + totalPoints, fTemp.end());
+			cusp::blas::fill(fView, 0.0);
+		}
 		cusp::multiply(ET, fTemp, F);
 		NSWithBody<memoryType>::B.forceX[l] = (dx*dy)/dx*thrust::reduce(F.begin(), F.end());
 		


### PR DESCRIPTION
Objectives:

* Fix the bug in the calculation of the drag force acting on an immersed body.

* Add restart functionality.

Problems:

* The drag force is not computed correctly. As an example, the following figure shows the unsteady drag coefficient acting on a snake cross-section immersed with an 35-degree angle-of-attack in a flow at a Reynolds number 2000:

![cuibm_re2000aoa35_dragcoefficients_problem](https://cloud.githubusercontent.com/assets/5657080/10925313/e2ea9538-825a-11e5-8e2f-ece25d0857ae.png)


We forgot to neglect the Eulerian forces in the y-direction when computing the force in the x-direction of the last immersed boundary. The bug was [introduced](https://github.com/barbagroup/cuIBM/commit/4e7f0da1259c73901a40b7ee22f9ebe29a3f8e18) when implementing the feature of having multiple immersed boundaries.

* Up to that point, a simulation could not be restarted.

Done:

* Neglect the forces in the y-direction when calculating the force in the x-direction on the last immersed body.

* The input parameter `startStep` can be used to restart a simulation (set to the initial time-step). If `startStep` has a no-zero value, the simulation is restarted and the fluxes are read from the file located in the time-step folder. In addition, the input parameter `nt` is not anymore the final time-step, but the number of time-steps to perform during the simulation. We also force the integration scheme to be Euler explicit for the convective terms during the first time-step.